### PR TITLE
C'est mieux si on oblige l'admin à remplir les champs Noms / quota / …

### DIFF
--- a/src/Shotgunutc/Field.php
+++ b/src/Shotgunutc/Field.php
@@ -52,7 +52,7 @@ class Field {
                 <label for="'.$this->field_name.'">'.$this->label.'</label>
                     '.$this->explanation.'
                 <div class="controls">
-                    <input type="'.$type.'" class="form-control" name="'.$this->field_name.'" value="'.$value.'" '.$more.'>                    
+                    <input required type="'.$type.'" class="form-control" name="'.$this->field_name.'" value="'.$value.'" '.$more.'>
                 </div>
             </div>';
     }

--- a/src/Shotgunutc/Select.php
+++ b/src/Shotgunutc/Select.php
@@ -44,7 +44,7 @@ class Select {
         <div class="form-group">
             <label for="'.$this->field_name.'">'.$this->label.'</label>
             <div class="controls">
-            <select name="'.$this->field_name.'[]" id="'.$this->field_name.'" class="" multiple="multiple" style="height:200px;">';
+            <select required name="'.$this->field_name.'[]" id="'.$this->field_name.'" class="" multiple="multiple" style="height:200px;">';
                 foreach ($this->options as $k => $v) {
                     if (is_array($v)) {
                         $renduHtml .= '<optgroup label="'.$k.'">';


### PR DESCRIPTION
…date & public_cible...

Sinon on avait une erreur Slim si le public n'était pas défini, et rien de rempli pour le reste.
On ne pouvait même pas cliquer sur un event pour l'éditer s'il n'avait pas le titre... (li vide, impossible de cliquer)